### PR TITLE
Melhora atualizações do semestre

### DIFF
--- a/App.js
+++ b/App.js
@@ -44,7 +44,7 @@ import * as Sentry from "sentry-expo";
 
 Sentry.init({
   dsn: "https://c1a9d3d02d424eaa91ee720bd5225f83@o4505104445079552.ingest.sentry.io/4505104464805888",
-  enableInExpoDevelopment: true,
+  enableInExpoDevelopment: false,
   debug: __DEV__,
 });
 

--- a/components/Progress.js
+++ b/components/Progress.js
@@ -6,10 +6,15 @@ import {
   heightPercentageToDP as hp,
   widthPercentageToDP as wp,
 } from "react-native-responsive-screen";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { ConfigSemester } from "../screens/dashboardScreens/Config";
 import { Portal, Dialog, Button } from "react-native-paper";
 import { PropTypes } from "prop-types";
+import {
+  isOldDefaultSemester,
+  latestDefaultSemester,
+} from "../helpers/defaultSemester";
+import { updateSemester } from "../redux/actions/semesterActions";
 
 function Bar(props) {
   const text = props.text || "";
@@ -67,7 +72,13 @@ function Bar(props) {
 Bar.propTypes = PropTypes.any;
 
 export default function Progress() {
+  const dispatch = useDispatch();
   const semester = useSelector((state) => state.semester).semester;
+
+  if (isOldDefaultSemester(semester)) {
+    dispatch(updateSemester(latestDefaultSemester()));
+  }
+
   const currentDate = new Date();
   let message = "";
   let progress = 0;

--- a/helpers/ExpressionHelper.js
+++ b/helpers/ExpressionHelper.js
@@ -68,15 +68,6 @@ export function getFrequency(task) {
   return "" + magic(task.grades.frequency, task.frequency).result;
 }
 
-
-
-// try {
-//     console.log(magic({c: 1, b: 2, j:1000 },"A + c + b + D*i"))
-// } catch(e){
-//     console.log("deu erro", e)
-// }
-
-
 export function BWFont(backgroundColor) {
   let r = 0,
     g = 0,

--- a/helpers/defaultSemester.ts
+++ b/helpers/defaultSemester.ts
@@ -1,0 +1,31 @@
+import { Semester } from "../redux/types/semester";
+
+const LAST_SEMESTER: Semester = {
+  init: "2022-11-07T03:02:00",
+  end: "2023-04-08T03:04:00",
+};
+
+const LATEST_SEMESTER: Semester = {
+  init: "2023-05-08T03:02:00",
+  end: "2023-09-09T03:04:00",
+};
+
+/**
+ * Verifica se um estado de semestre é o semestre padrão anterior.
+ * @param semester - O semestre para verificar.
+ * @returns Se o valor é o semestre anterior ou não.
+ */
+export function isOldDefaultSemester(semester: Semester): boolean {
+  return (
+    semester.init == LAST_SEMESTER.init &&
+    semester.end == LAST_SEMESTER.end
+  );
+}
+
+/**
+ * Retorna o semestre padrão mais recente.
+ * @returns O semestre padrão mais recente.
+ */
+export function latestDefaultSemester(): Semester {
+  return LATEST_SEMESTER;
+}

--- a/redux/actions/semesterActions.ts
+++ b/redux/actions/semesterActions.ts
@@ -1,9 +1,9 @@
 import { ActionType } from "../constants/actionType";
-import { SemesterState } from "../types/semester";
+import { Semester } from "../types/semester";
 
 export type UpdateSemesterAction = {
   type: ActionType.UPDATE_SEMESTER,
-  payload: SemesterState["semester"],
+  payload: Semester,
 }
 
 /**
@@ -12,9 +12,7 @@ export type UpdateSemesterAction = {
  * persistente.
  * @returns A ação para despachar.
  */
-export const updateSemester = (
-  semester: SemesterState["semester"],
-): UpdateSemesterAction => {
+export const updateSemester = (semester: Semester): UpdateSemesterAction => {
   return {
     type: ActionType.UPDATE_SEMESTER,
     payload: semester,

--- a/redux/reducers/semesterReducer.ts
+++ b/redux/reducers/semesterReducer.ts
@@ -1,11 +1,9 @@
+import { latestDefaultSemester } from "../../helpers/defaultSemester";
 import { Action, ActionType } from "../constants/actionType";
 import { SemesterState } from "../types/semester";
 
 const initialState: SemesterState = {
-  semester: {
-    init: "2022-11-07T03:02:00",
-    end: "2023-04-08T03:04:00",
-  },
+  semester: latestDefaultSemester(),
 };
 
 export const semesterReducer = (

--- a/redux/types/semester.ts
+++ b/redux/types/semester.ts
@@ -1,14 +1,16 @@
-export type SemesterState = {
-  semester: {
-    /**
-     * Uma string no formato ISO-8601 contendo a data e hora do início do
-     * semestre.
-     */
-    init: string,
+export type Semester = {
+  /**
+   * Uma string no formato ISO-8601 contendo a data e hora do início do
+   * semestre.
+   */
+  init: string,
 
-    /**
-     * Uma string no formato ISO-8601 contendo a data e hora do fim do semestre.
-     */
-    end: string,
-  }
+  /**
+   * Uma string no formato ISO-8601 contendo a data e hora do fim do semestre.
+   */
+  end: string,
+};
+
+export type SemesterState = {
+  semester: Semester,
 }

--- a/screens/dashboardScreens/Siga.js
+++ b/screens/dashboardScreens/Siga.js
@@ -21,6 +21,8 @@ import {
 } from "../../redux/actions/eventActions";
 import Toast from "react-native-toast-message";
 import { Buffer } from "buffer";
+import { updateSemester } from "../../redux/actions/semesterActions";
+import { latestDefaultSemester } from "../../helpers/defaultSemester";
 
 export const addSigaSubject = (subject, dispatch) => {
   let auxdetails = [];
@@ -78,6 +80,7 @@ export default function SigaScreen() {
           const subjects = data.data;
           try {
             dispatch(removeSIGA());
+            dispatch(updateSemester(latestDefaultSemester()));
             for (let i = 0; i < subjects.length; i++) {
               addSigaSubject(subjects[i], dispatch);
             }

--- a/screens/dashboardScreens/Siga.js
+++ b/screens/dashboardScreens/Siga.js
@@ -69,6 +69,7 @@ export default function SigaScreen() {
         },
       );
       let data = await response.json();
+      dispatch(updateSemester(latestDefaultSemester()));
       if (data.status == undefined) {
         if (data.length == 0) {
           setMessageE(
@@ -80,7 +81,6 @@ export default function SigaScreen() {
           const subjects = data.data;
           try {
             dispatch(removeSIGA());
-            dispatch(updateSemester(latestDefaultSemester()));
             for (let i = 0; i < subjects.length; i++) {
               addSigaSubject(subjects[i], dispatch);
             }


### PR DESCRIPTION
O semestre novo agora verifica se o anterior era o padrão e se coloca no lugar dele se for o caso. Além disso, a importação de matérias pelo SIGA também atualiza o semestre para o padrão mais novo.

Essa solução está aqui como um placeholder barato até conseguirmos trabalhar em cima da #46.