### PR TITLE
Imprecisão em float causava um número de refeições incorreto.

### DIFF
--- a/components/RestaurantTicket.js
+++ b/components/RestaurantTicket.js
@@ -134,7 +134,7 @@ export default function RestaurantTicket(props) {
     },
   });
 
-  const qtdRefeicoes = Math.floor(user.money / user.meal);
+  const qtdRefeicoes = Math.floor( ( user.money * 10 * 10 ) / ( user.meal * 10 * 10) );
   const refeicao = qtdRefeicoes == 1 ? "refeição" : "refeições";
   const navigation = useNavigation();
   return (

--- a/components/RestaurantTicket.js
+++ b/components/RestaurantTicket.js
@@ -134,7 +134,9 @@ export default function RestaurantTicket(props) {
     },
   });
 
-  const qtdRefeicoes = Math.floor( ( user.money * 10 * 10 ) / ( user.meal * 10 * 10) );
+  const qtdRefeicoes = Math.floor(
+    user.money * 10 * 10  / (user.meal * 10 * 10),
+  );
   const refeicao = qtdRefeicoes == 1 ? "refeição" : "refeições";
   const navigation = useNavigation();
   return (
@@ -230,7 +232,9 @@ export default function RestaurantTicket(props) {
             >Cancelar</Button>
             <Button
               disabled={
-                value.search(/^\$?\d+(((.\d{3})*(,\d*))|((,\d{3})*(\.\d*)))?$/) < 0
+                value.search(
+                  /^\$?\d+(((.\d{3})*(,\d*))|((,\d{3})*(\.\d*)))?$/,
+                ) < 0
               }
               onPress={() => {
                 handleCashChange();


### PR DESCRIPTION
**Repetição do erro:**

O cálculo do número de refeições sofria com a imprecisão na divisão de 2 floats:
![image](https://github.com/petbccufscar/ufscar-planner/assets/45954188/7e89cb1b-6699-4133-b74e-4a6b4023dff4)

Se o saldo fosse R$ 37,8 o aplicativo mostraria 8 refeições quando o correto é de 9 refeições até o saldo esgotar
(considerando o preço da refeição como R$ 4,20)

A multiplicação por 10 duas vezes tenta forçar uma divisão de número inteiros, já que os centavos só ocupam duas casas decimais ( * 10^2) e, com isso, eliminar a imprecisão causada pelo float

*é necessário multiplicar por 10 duas vezes ao invés de * 100, pois computadores são estranhos
![image](https://github.com/petbccufscar/ufscar-planner/assets/45954188/49c01923-19f2-46e4-94c9-dd92103cbdab)

...e um salve pro Maykon e pra Vitória de ENC que me apresentaram o erro